### PR TITLE
issue_127 : Refactored update_order() so it only takes one argument. …

### DIFF
--- a/CodingPractice/PythonAssignments/shoppingcart/dao/OrderDao.py
+++ b/CodingPractice/PythonAssignments/shoppingcart/dao/OrderDao.py
@@ -28,5 +28,5 @@ class OrderDao(ABC):
         return
 
     @abstractmethod
-    def update_order(self, order_dto, new_order_dto):
+    def update_order(self, order_dto):
         return

--- a/CodingPractice/PythonAssignments/shoppingcart/dao/json/OrderJsonDao.py
+++ b/CodingPractice/PythonAssignments/shoppingcart/dao/json/OrderJsonDao.py
@@ -57,5 +57,5 @@ class OrderJsonDao(OrderDao, JsonFileReader):
     def delete_order(self, order_dto):
         raise MethodNotImplementedException('delete_order called on OrderJsonDao')
 
-    def update_order(self, order_dto, new_order_dto):
+    def update_order(self, order_dto):
         raise MethodNotImplementedException('update_order called on OrderJsonDao')

--- a/CodingPractice/PythonAssignments/shoppingcart/dao/postgres/OrderPostgresDao.py
+++ b/CodingPractice/PythonAssignments/shoppingcart/dao/postgres/OrderPostgresDao.py
@@ -113,11 +113,11 @@ class OrderPostgresDao(OrderDao):
         with closing(self._postgres_conn.cursor()) as cursor:
             cursor.execute(f"DELETE FROM order_line WHERE order_id={order_id};")
 
-    def update_order(self, order_dto, new_order_dto):
+    def update_order(self, order_dto):
         try:
             self._BEGIN()
             self._delete_orders_and_order_lines(order_dto.get_order_id())
-            self.create_order(new_order_dto)
+            self.create_order(order_dto)
             self._COMMIT()
         except Exception as e:
             self._ROLLBACK()

--- a/CodingPractice/PythonAssignments/tests/shoppingcart/dao/json/test_OrderJsonDao.py
+++ b/CodingPractice/PythonAssignments/tests/shoppingcart/dao/json/test_OrderJsonDao.py
@@ -82,7 +82,7 @@ class TestOrderJsonDao(unittest.TestCase):
 
     def test_10_MethodNotImplementedException_raised_on_update_order(self):
         with self.assertRaises(MethodNotImplementedException) as e:
-            self._orderDao.update_order(None, None)
+            self._orderDao.update_order(None)
         self.assertEqual('update_order called on OrderJsonDao', e.exception._message)
 
 

--- a/CodingPractice/PythonAssignments/tests/shoppingcart/dao/postgres/test_OrderPostgresDao.py
+++ b/CodingPractice/PythonAssignments/tests/shoppingcart/dao/postgres/test_OrderPostgresDao.py
@@ -147,19 +147,19 @@ class OrderPostgresDaoTests(unittest.TestCase):
                                  [OrderLineDto(777, 1, 10),
                                   OrderLineDto(777, 2, 45)])
         type(self).dao.create_order(order)
-        type(self).dao.update_order(order, updated_order)
+        type(self).dao.update_order(updated_order)
         actual = type(self).dao.get_order_by_order_id(777)
         self.assertEqual([updated_order], actual)
 
     def test_09_ROLLBACK_works_after_update_order_fails(self):
-        order = OrderDto(77, 2, "2019-12-01 10:15:23", 1,
-                         [OrderLineDto(77, 1, 50),
-                          OrderLineDto(77, 2, 100)])
+        order = OrderDto(65, 2, "2019-12-01 10:15:23", 1,
+                         [OrderLineDto('abc', 1, 50),
+                          OrderLineDto(65, 2, 100)])
 
         with self.assertRaises(Exception) as e:
             type(self).dao.update_order(order)
 
-        actual = type(self).dao.get_order_by_order_id(77)
+        actual = type(self).dao.get_order_by_order_id(65)
         self.assertEqual([], actual)
 
     def test_10_ROLLBACK_occurs_when_delete_fails_in_update_order(self):
@@ -177,7 +177,7 @@ class OrderPostgresDaoTests(unittest.TestCase):
                                  [OrderLineDto(777, 1, 10),
                                   OrderLineDto(777, 2, 45)])
 
-        type(self).dao.update_order(order2, updated_order)
+        type(self).dao.update_order(updated_order)
         actual = type(self).dao.get_order_by_order_id(777)
         self.assertEqual([updated_order], actual)
 
@@ -192,7 +192,7 @@ class OrderPostgresDaoTests(unittest.TestCase):
                                   OrderLineDto(654, 2, 45)])
 
         with self.assertRaises(Exception) as e:
-            type(self).dao.update_order(order, updated_order)
+            type(self).dao.update_order(updated_order)
 
         actual = type(self).dao.get_order_by_order_id(654)
         self.assertEqual([order], actual)


### PR DESCRIPTION
…This required refactoring some of the tests, as well as ensuring that the create_order() function call within update_order() takes an orderDTO.